### PR TITLE
Remove BuildKit references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,25 +6,7 @@ This action builds Docker images and deploys them via GitOps to Kubernetes clust
 
 - ✅ Builds and pushes Docker images to Azure Container Registry
 - ✅ Automatically updates GitOps repository with new image tags
-- ✅ **Smart BuildKit detection**: Uses persistent BuildKit cache on self-hosted runners for faster builds
-- ✅ **Cross-runner compatibility**: Works seamlessly on GitHub-hosted, Warp, and self-hosted runners
 - ✅ Supports custom deployment file paths for complex deployments
-
-## Performance Optimization
-
-The action automatically detects if a persistent BuildKit service is available (on self-hosted runners) and uses it for caching:
-
-| Runner Type | BuildKit Mode | Cache Behavior | Build Time |
-|-------------|---------------|----------------|------------|
-| Self-hosted (ARC) | Persistent BuildKit | ✅ Cached (NuGet, layers, base images) | ~2m 30s |
-| GitHub-hosted | Ephemeral | ❌ No cache | ~4m 30s |
-| Warp | Ephemeral | ❌ No cache | ~4m 30s |
-
-On self-hosted runners with persistent BuildKit, you can expect:
-- **45% faster builds** after the first build
-- **Cached NuGet packages** (saves ~70s)
-- **Cached base images** (saves ~20s)
-- **Reused BuildKit instance** (saves ~25s)
 
 ## Usage
 
@@ -54,60 +36,6 @@ jobs:
           github-app-installation-id: ${{ secrets.LIKVIDO_DEPLOYMENT_PUSHER_INSTALLATION_ID }}
           gitops-deployment-file: 'my/deployment/file.yaml'
 ```
-
-## Maximizing Build Performance with Cache Mounts
-
-To get the full benefit of persistent BuildKit on self-hosted runners, add cache mounts to your Dockerfiles:
-
-### Before (no caching):
-```dockerfile
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-WORKDIR /src
-COPY . .
-RUN dotnet restore "MyApp.csproj"
-RUN dotnet build "MyApp.csproj" -c Release
-RUN dotnet publish "MyApp.csproj" -c Release -o /app/publish
-```
-
-### After (with cache mounts):
-```dockerfile
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-WORKDIR /src
-COPY . .
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet restore "MyApp.csproj"
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet build "MyApp.csproj" -c Release
-RUN --mount=type=cache,target=/root/.nuget/packages \
-    dotnet publish "MyApp.csproj" -c Release -o /app/publish
-```
-
-**Important**: Cache mounts require BuildKit. This action automatically uses BuildKit when available, so no additional configuration is needed.
-
-On runners **without** persistent BuildKit (GitHub-hosted, Warp):
-- Cache mounts still work within a single build (saves time between restore/build/publish)
-- Cache is lost between builds
-- Still provides ~20s savings per build
-
-On runners **with** persistent BuildKit (self-hosted ARC):
-- Cache persists across all builds
-- Full ~70s savings for NuGet packages
-- Maximum performance benefit
-
-## How BuildKit Detection Works
-
-The action uses this logic to determine which BuildKit to use:
-
-```
-1. Check if buildkitd.github-arc-runners.svc.cluster.local:1234 is reachable
-2. If YES → Use persistent BuildKit (self-hosted runner)
-3. If NO  → Use ephemeral BuildKit (GitHub-hosted/Warp runner)
-```
-
-This means:
-- ✅ **No configuration needed** - works automatically
-- ✅ **No breaking changes** - existing workflows continue to work
-- ✅ **Optimal performance** - uses best available BuildKit for each runner type
 
 ## Inputs
 


### PR DESCRIPTION
## Summary
- Removed BuildKit detection feature from Features section
- Removed Performance Optimization section with BuildKit caching details
- Removed Cache mounts documentation section
- Removed BuildKit detection logic explanation section

## Reason
The action no longer includes BuildKit functionality, so all references to BuildKit have been removed from the documentation to keep it accurate and up-to-date.

## Test plan
- [ ] Review the updated README to ensure all BuildKit references have been removed
- [ ] Verify that the remaining documentation is coherent and complete
- [ ] Confirm no broken links or formatting issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed performance optimization guidance and BuildKit detection sections from documentation.
  * Streamlined documentation by removing outdated feature references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->