### PR TITLE
Revert BaGetter NUGET_SOURCE integration

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,10 +59,6 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
-    - name: Capture NUGET_SOURCE from environment
-      run: echo "NUGET_SOURCE_VALUE=${NUGET_SOURCE:-}" >> $GITHUB_ENV
-      shell: bash
-
     - name: Build & push Docker image
       uses: docker/build-push-action@v6
       with:
@@ -70,8 +66,6 @@ runs:
         file: ${{ inputs.docker-working-directory }}/${{ inputs.docker-file-relative }}
         push: true
         tags: ${{ env.IMAGE_NAME }}
-        build-args: |
-          NUGET_SOURCE=${{ env.NUGET_SOURCE_VALUE }}
 
     # GitOps deploy
     - name: Push Deployment Update


### PR DESCRIPTION
## Summary
This PR reverts the BaGetter NUGET_SOURCE integration introduced in v3.7, returning to v3.6 behavior.

### Changes Made
- Removed the "Capture NUGET_SOURCE from environment" step
- Removed `build-args` section passing NUGET_SOURCE to Docker build
- Builds will now use nuget.org directly instead of BaGetter cache

### Rationale
Decision: 15% build improvement doesn't justify maintenance overhead.

### Version
This change is tagged as `v3.8`.

### Impact
- Existing workflows using `@v3.7` will continue to use BaGetter
- Workflows can be updated to `@v3.8` to use the reverted behavior
- Using `@v3` will automatically pick up the latest v3.x (v3.8)

## Test plan
- [ ] Verify YAML syntax is correct
- [ ] Confirm proper indentation maintained
- [ ] Ensure no orphaned configuration keys
- [ ] Validate action still builds Docker images successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed NuGet source configuration from Docker build process to prevent unintended environment variable forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->